### PR TITLE
remove duplication? in the pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <release>11</release>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
A few groups ran into a problem when changing from java 11 to java 8. It had to be changed in 3 places. It seems to me that the use of the maven-compiler-plugin configuration is no necessary given the two options in the <properties> section.  I removed them, it works fine for me switching between java 11 and 8.

Just in case: @emilybache was there some specific reason to add the <release>11<option> and the specific version of maven-compiler-plugin?